### PR TITLE
TOOLS-2452 add Jenkinsfiles for final molybdenum jenkinsBuildHook repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,9 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
+export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
-# XXX timf print-bits-upload to prevent modifying production data
-make print-BRANCH print-STAMP triton-origin-multiarch-15.4.1-"buildimage print-bits-upload"
+make print-BRANCH print-STAMP triton-origin-multiarch-15.4.1-"buildimage bits-upload"
 ''')
             }
         }
@@ -92,13 +92,14 @@ make print-BRANCH print-STAMP triton-origin-multiarch-15.4.1-"buildimage print-b
             }
             steps {
                 sh('''
-    export TRACE=1
+export TRACE=1
 
-    set -o errexit
-    set -o pipefail
-    make clean distclean
-    export ENGBLD_BITS_UPLOAD_IMGAPI=true
-    make print-BRANCH print-STAMP triton-origin-multiarch-18.1.0-"buildimage print-bits-upload"
+set -o errexit
+set -o pipefail
+make clean distclean
+export UPDATES_IMGADM_CHANNEL=experimental
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+make print-BRANCH print-STAMP triton-origin-multiarch-18.1.0-"buildimage bits-upload"
     ''')
             }
         }
@@ -119,9 +120,9 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
+export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
-# XXX timf print-bits-upload to prevent modifying production data
-make print-BRANCH print-STAMP triton-origin-x86_64-18.4.0-"buildimage print-bits-upload"
+make print-BRANCH print-STAMP triton-origin-x86_64-18.4.0-"buildimage bits-upload"
 ''')
             }
         }
@@ -140,11 +141,10 @@ make print-BRANCH print-STAMP triton-origin-x86_64-18.4.0-"buildimage print-bits
 export TRACE=1
 set -o errexit
 set -o pipefail
-#export UPDATES_IMGADM_CHANNEL=experimental
 make clean distclean
+export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
-# XXX timf print-bits-upload to prevent modifying production data
-make print-BRANCH print-STAMP triton-origin-x86_64-19.1.0-"buildimage print-bits-upload"
+make print-BRANCH print-STAMP triton-origin-x86_64-19.1.0-"buildimage bits-upload"
 ''')
             }
         }
@@ -163,11 +163,10 @@ make print-BRANCH print-STAMP triton-origin-x86_64-19.1.0-"buildimage print-bits
 export TRACE=1
 set -o errexit
 set -o pipefail
-#export UPDATES_IMGADM_CHANNEL=experimental
 make clean distclean
-#export ENGBLD_BITS_UPLOAD_IMGAPI=true
-# XXX timf print-bits-upload to prevent modifying production data
-make print-BRANCH print-STAMP triton-origin-x86_64-19.2.0-"buildimage print-bits-upload"
+export UPDATES_IMGADM_CHANNEL=experimental
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+make print-BRANCH print-STAMP triton-origin-x86_64-19.2.0-"buildimage bits-upload"
 ''')
             }
         }
@@ -186,11 +185,10 @@ make print-BRANCH print-STAMP triton-origin-x86_64-19.2.0-"buildimage print-bits
 export TRACE=1
 set -o errexit
 set -o pipefail
-#export UPDATES_IMGADM_CHANNEL=experimental
 make clean distclean
-#export ENGBLD_BITS_UPLOAD_IMGAPI=true
-# XXX timf print-bits-upload to prevent modifying production data
-make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage print-bits-upload"
+export UPDATES_IMGADM_CHANNEL=experimental
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage bits-upload"
 ''')
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-multiarch-15.4.1-"buildimage bits-upload"
 ''')
@@ -97,7 +96,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-multiarch-18.1.0-"buildimage bits-upload"
     ''')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-x86_64-18.4.0-"buildimage bits-upload"
 ''')
@@ -142,7 +141,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-x86_64-19.1.0-"buildimage bits-upload"
 ''')
@@ -164,7 +162,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-x86_64-19.2.0-"buildimage bits-upload"
 ''')
@@ -186,7 +183,6 @@ export TRACE=1
 set -o errexit
 set -o pipefail
 make clean distclean
-export UPDATES_IMGADM_CHANNEL=experimental
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage bits-upload"
 ''')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,204 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+@Library('jenkins-joylib@v1.0.4') _
+
+pipeline {
+
+    agent none
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+        timestamps()
+    }
+    parameters {
+        booleanParam(
+            name: 'BUILD_15_4_1',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-multiarch-15.4.1'
+        )
+        booleanParam(
+            name: 'BUILD_18_1_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-multiarch-18.1.0'
+        )
+        booleanParam(
+            name: 'BUILD_18_4_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-x86_64-18.4.0'
+        )
+        booleanParam(
+            name: 'BUILD_19_1_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-x86_64-19.1.0'
+        )
+        booleanParam(
+            name: 'BUILD_19_2_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-x86_64-19.2.0'
+        )
+        booleanParam(
+            name: 'BUILD_19_4_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-x86_64-19.4.0'
+        )
+    }
+    stages {
+        stage('triton-origin-multiarch-15.4.1') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '15.4.1')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_15_4_1', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+
+set -o errexit
+set -o pipefail
+make clean distclean
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+# XXX timf print-bits-upload to prevent modifying production data
+make print-BRANCH print-STAMP triton-origin-multiarch-15.4.1-"buildimage print-bits-upload"
+''')
+            }
+        }
+        stage('triton-origin-multiarch-18.1.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '18.1.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_18_1_0', value: 'true'
+            }
+            steps {
+                sh('''
+    export TRACE=1
+
+    set -o errexit
+    set -o pipefail
+    make clean distclean
+    export ENGBLD_BITS_UPLOAD_IMGAPI=true
+    make print-BRANCH print-STAMP triton-origin-multiarch-18.1.0-"buildimage print-bits-upload"
+    ''')
+            }
+        }
+        stage('triton-origin-x86_64-18.4.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '18.4.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_18_4_0', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+
+set -o errexit
+set -o pipefail
+make clean distclean
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+# XXX timf print-bits-upload to prevent modifying production data
+make print-BRANCH print-STAMP triton-origin-x86_64-18.4.0-"buildimage print-bits-upload"
+''')
+            }
+        }
+        stage('triton-origin-image-x86_64-19.1.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '19.1.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_19_1_0', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+set -o errexit
+set -o pipefail
+#export UPDATES_IMGADM_CHANNEL=experimental
+make clean distclean
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+# XXX timf print-bits-upload to prevent modifying production data
+make print-BRANCH print-STAMP triton-origin-x86_64-19.1.0-"buildimage print-bits-upload"
+''')
+            }
+        }
+        stage('triton-origin-image-x86_64-19.2.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '19.2.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_19_2_0', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+set -o errexit
+set -o pipefail
+#export UPDATES_IMGADM_CHANNEL=experimental
+make clean distclean
+#export ENGBLD_BITS_UPLOAD_IMGAPI=true
+# XXX timf print-bits-upload to prevent modifying production data
+make print-BRANCH print-STAMP triton-origin-x86_64-19.2.0-"buildimage print-bits-upload"
+''')
+            }
+        }
+        stage('triton-origin-image-x86_64-19.4.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '19.4.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_19_4_0', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+set -o errexit
+set -o pipefail
+#export UPDATES_IMGADM_CHANNEL=experimental
+make clean distclean
+#export ENGBLD_BITS_UPLOAD_IMGAPI=true
+# XXX timf print-bits-upload to prevent modifying production data
+make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage print-bits-upload"
+''')
+            }
+        }
+    }
+
+    post {
+        always {
+            joyMattermostNotification()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ to using a triton-origin image.
 
         NODE_PREBUILT_IMAGE=1ad363ec-3b83-11e8-8521-2f68a4a34d5d
 
-5. Update Jenkins (Joyent's current CI system) configuration for your
-   component's job to get an appropriate Jenkins Agent. Specifically the
-   "Label Expression" of the job configuration needs to be updated.
+5. Update Jenkinsfile to add a stage for the image you're building, taking care
+   to specify the correct `joyCommonLabels(..)` expression for your image,
+   adding a parameter to allow building of the individual image, and modifying
+   the `make` command line arguments for your pipeline stage.
    See the compatibility table below.
 
 
@@ -198,9 +199,11 @@ RFD 165 for later revisions.
 
 ### Building triton-origin images
 
-Official builds are done by the "triton-origin-image" Jenkins jobs.
+Official builds are done by the "triton-origin-image.git" Jenkins job. This job
+does not build automatically, and will only build the pipeline stages you
+select as parameters at build-time.
 
-You can build them on your workstation using the standard engbld targets (such
+You can build images on your workstation using the standard engbld targets (such
 as `buildimage` or `bits-upload`).  Because there are multiple origin images
 defined, there are a few different ways to invoke the targets.  Examples:
 
@@ -283,7 +286,7 @@ How to release a new triton-origin image:
    - Build and provision new Jenkins Agents to Joyent Engineering's CI system
      for building core components on this image. See
      <https://github.com/joyent/jenkins-agent> for details and speak to JoshW,
-     ChrisB, or Trent.
+     TimF, or Trent.
    - Add sdcnode builds for this new image. See
      <https://github.com/joyent/sdcnode>.
 


### PR DESCRIPTION
The intent with this change is that we do _not_ automatically do builds of all origin images when pushing a change to 'master'. Instead, we only build an origin image when a user has specified which of the builds to do.

Creating new origin images is a rare occurrence and I'd rather we had this as a manual process. However, consolidating all of the freestyle jobs into a single Jenkinsfile contained in the workspace still makes sense.