### PR TITLE
TRITON-2277 triton-origin-x86_64-21.4.0 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /npm-debug.log
 /make_stamps
 /bits
+/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 /tmp
 /build
 /npm-debug.log
-/make_stamps
+make_stamps
 /bits
 /package-lock.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,8 @@ make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage bits-uploa
         stage('triton-origin-image-x86_64-21.4.0') {
             agent {
                 node {
-                    label joyCommonLabels(image_ver: '21.4.0')
+                    label joyCommonLabels(image_ver: '21.4.0',
+                        pi:'20210826T002459Z'')
                 }
             }
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2021 Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -36,6 +36,12 @@ pipeline {
             defaultValue: false,
             description: 'This parameter declares whether to build ' +
                 'triton-origin-x86_64-19.4.0'
+        )
+        booleanParam(
+            name: 'BUILD_21_4_0',
+            defaultValue: false,
+            description: 'This parameter declares whether to build ' +
+                'triton-origin-x86_64-21.4.0'
         )
     }
     stages {
@@ -101,6 +107,27 @@ set -o pipefail
 make clean distclean
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage bits-upload"
+''')
+            }
+        }
+        stage('triton-origin-image-x86_64-21.4.0') {
+            agent {
+                node {
+                    label joyCommonLabels(image_ver: '21.4.0')
+                }
+            }
+            when {
+                beforeAgent true
+                environment name: 'BUILD_21_4_0', value: 'true'
+            }
+            steps {
+                sh('''
+export TRACE=1
+set -o errexit
+set -o pipefail
+make clean distclean
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+make print-BRANCH print-STAMP triton-origin-x86_64-21.4.0-"buildimage bits-upload"
 ''')
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ make print-BRANCH print-STAMP triton-origin-x86_64-19.4.0-"buildimage bits-uploa
             agent {
                 node {
                     label joyCommonLabels(image_ver: '21.4.0',
-                        pi:'20210826T002459Z'')
+                        pi:'20210826T002459Z')
                 }
             }
             when {

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ DIST_CLEAN_FILES += ./node_modules/ ./build ./bits
 NPM = npm
 JSON = ./node_modules/.bin/json
 
+ALL_TARGETS = triton-origin-multiarch-15.4.1-%
+ALL_TARGETS += triton-origin-x86_64-18.4.0-%
+ALL_TARGETS += triton-origin-x86_64-19.4.0-%
+ALL_TARGETS += triton-origin-x86_64-21.4.0-%
+
 #
 # Targets
 #
@@ -57,30 +62,28 @@ cutarelease: check-version
 #
 triton-origin-multiarch-15.4.1-%:
 	@echo '$*'
+	rm make_stamps ; ln -s images/triton-origin-multiarch-15.4.1/make_stamps make_stamps
 	cd images/triton-origin-multiarch-15.4.1 && $(MAKE) $*
 
 triton-origin-x86_64-18.4.0-%:
 	@echo '$*'
+	rm make_stamps ; ln -s images/triton-origin-x86_64-18.4.0/make_stamps make_stamps
 	cd images/triton-origin-x86_64-18.4.0 && $(MAKE) $*
 
 triton-origin-x86_64-19.4.0-%:
 	@echo '$*'
+	rm make_stamps ; ln -s images/triton-origin-x86_64-19.4.0/make_stamps make_stamps
 	cd images/triton-origin-x86_64-19.4.0 && $(MAKE) $*
 
 triton-origin-x86_64-21.4.0-%:
 	@echo '$*'
+	rm make_stamps ; ln -s images/triton-origin-x86_64-21.4.0/make_stamps make_stamps
 	cd images/triton-origin-x86_64-21.4.0 && $(MAKE) $*
 
 #
 # Convenience wrapper to run the same target for each image
 #
-all-%:
+all-%: $(ALL_TARGETS)
 	@echo '$*'
-	cd images/triton-origin-multiarch-15.4.1 && $(MAKE) $*
-	cd images/triton-origin-x86_64-18.4.0 && $(MAKE) $*
-	cd images/triton-origin-x86_64-19.4.0 && $(MAKE) $*
-	cd images/triton-origin-x86_64-21.4.0 && $(MAKE) $*
-
-
 
 include ./deps/eng/tools/mk/Makefile.targ

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 #
-# Copyright 2020 Joyent, Inc.
+# Copyright 2022 Joyent, Inc.
 #
 
 #
@@ -67,6 +67,10 @@ triton-origin-x86_64-19.4.0-%:
 	@echo '$*'
 	cd images/triton-origin-x86_64-19.4.0 && $(MAKE) $*
 
+triton-origin-x86_64-21.4.0-%:
+	@echo '$*'
+	cd images/triton-origin-x86_64-21.4.0 && $(MAKE) $*
+
 #
 # Convenience wrapper to run the same target for each image
 #
@@ -75,6 +79,7 @@ all-%:
 	cd images/triton-origin-multiarch-15.4.1 && $(MAKE) $*
 	cd images/triton-origin-x86_64-18.4.0 && $(MAKE) $*
 	cd images/triton-origin-x86_64-19.4.0 && $(MAKE) $*
+	cd images/triton-origin-x86_64-21.4.0 && $(MAKE) $*
 
 
 

--- a/Makefile.origin.defs
+++ b/Makefile.origin.defs
@@ -10,7 +10,7 @@
 
 # Definitions (or overrides) for variables defined in the "eng" Makefiles
 ENGBLD_REQUIRE := $(shell git submodule update --init $(TOP)/deps/eng)
-MAKE_STAMPS_DIR:=$(TOP)/make_stamps
+MAKE_STAMPS_DIR:=make_stamps
 GITHASH := $(shell git log -1 --pretty='%H')
 ENGBLD_USE_BUILDIMAGE:=true
 

--- a/images/triton-origin-x86_64-21.4.0/Makefile
+++ b/images/triton-origin-x86_64-21.4.0/Makefile
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2022 Joyent, Inc.
+#
+
+NAME=triton-origin-x86_64-21.4.0
+TOP=$(shell git rev-parse --show-toplevel)
+
+include $(TOP)/Makefile.origin.defs
+include $(TOP)/deps/eng/tools/mk/Makefile.defs
+
+BUILDIMAGE_DO_PKGSRC_UPGRADE:=true
+
+# minimal-64-lts@21.4.0
+BASE_IMAGE_UUID = a7199134-7e94-11ec-be67-db6f482136c2
+BUILDIMAGE_NAME = ${NAME}
+BUILDIMAGE_DESC = Triton/Manta component origin image based on x86_64 21.4.0
+BUILDIMAGE_PKGSRC = coreutils curl gsed patch sudo
+
+include $(TOP)/deps/eng/tools/mk/Makefile.targ

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton-origin-image",
   "description": "origin images for Triton DataCenter core components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "homepage": "https://github.com/joyent/triton-origin-image",


### PR DESCRIPTION
This allows building of triton-origin-images, and resolves conflicts with updates to eng.git that happened over time.

**Note:** joyent/eng#54 *must* be merged, and this branch submodule updated to the new commit *before* this may be merged.