### PR TITLE
TRITON-2472 triton-origin-x86_64-24.4.1 image (fix)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,6 +185,7 @@ set -o errexit
 set -o pipefail
 make clean distclean
 export ENGBLD_BITS_UPLOAD_IMGAPI=true
+export ENGBLD_FORCE_LOCAL_BUILDIMAGE=true
 make print-BRANCH print-STAMP triton-origin-x86_64-24.4.1-"buildimage bits-upload"
 ''')
             }


### PR DESCRIPTION
This includes a couple of follow-up commits to resolve issues seen when trying to generate the 24.4.1 image in Jenkins:

* The locally installed copy of `buildimage` was being used from `/opt/tools/bin/buildimage` instead of the pristine version from eng.git. The local copy appears to have some hardcoded changes for 21.4.0 that end up breaking the 24.4.1 image.
* The eng.git submodule was out-of-date and needs updating.

This build looks better on my test host, but I can't confirm this for certain until it is tested on the actual Jenkins build hosts as they are configured differently.